### PR TITLE
Fix achievements API version number.

### DIFF
--- a/steamapi/app.py
+++ b/steamapi/app.py
@@ -61,7 +61,7 @@ class SteamApp(SteamObject):
             userid = self._userid
             unlocks = APIConnection().call("ISteamUserStats",
                                            "GetUserStatsForGame",
-                                           "v2",
+                                           "v0002",
                                            appid=self._id,
                                            steamid=userid)
             if 'achievements' in unlocks.playerstats:


### PR DESCRIPTION
Calling `achievements` on an app object is returning an error. This fixes the problem by updating the version number of the API. Oddly, a direct browser-based call with “v2” in the URL still works, but the python library invocation isn’t happy.

I may come across other examples as I go, I can add to this PR if need be. Nice library BTW, thanks.
